### PR TITLE
Explicit email track

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -72,13 +72,21 @@ exports.track = function(track) {
       }
     });
   } else {
+    if (typeof track.proxy('context.traits.email') !== 'undefined'){
+      this.identity = {
+        id: track.userId(),
+        email: track.proxy('context.traits.email')
+      }
+    } else {
+      this.identity = {
+        id: track.userId()
+      }
+    }
     return reject(addCommon(track, {
       auth_token: this.settings.authToken,
       event_name: track.event(),
       data: track.properties(),
-      identity: {
-        id: track.userId()
-      },
+      identity: this.identity,
       extras: {
         created_at: time(track.timestamp()),
         source: 'segment'

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -72,13 +72,14 @@ exports.track = function(track) {
       }
     });
   } else {
+    var identity; 
     if (typeof track.proxy('context.traits.email') !== 'undefined'){
-      this.identity = {
+      identity = {
         id: track.userId(),
         email: track.proxy('context.traits.email')
       }
     } else {
-      this.identity = {
+      identity = {
         id: track.userId()
       }
     }
@@ -86,7 +87,7 @@ exports.track = function(track) {
       auth_token: this.settings.authToken,
       event_name: track.event(),
       data: track.properties(),
-      identity: this.identity,
+      identity: identity,
       extras: {
         created_at: time(track.timestamp()),
         source: 'segment'

--- a/test/fixtures/track-with-email.json
+++ b/test/fixtures/track-with-email.json
@@ -1,0 +1,44 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "event": "my-event",
+    "properties": {
+      "avatar": "avatar.jpg",
+      "country": "some-country",
+      "name": "John Doe",
+      "gender": "male",
+      "email": "jd@example.com",
+      "phone": "55555",
+      "city": "some-city",
+      "age": "age"
+    },
+    "context": {
+      "traits": {
+        "email": "user-email@example.com"
+      }
+    }
+  },
+  "output": {
+    "event_name": "my-event",
+    "extras": {
+      "created_at": 1388534400,
+      "source": "segment"
+    },
+    "identity": {
+      "id": "user-id",
+      "email": "user-email@example.com"
+    },
+    "data": {
+      "avatar": "avatar.jpg",
+      "country": "some-country",
+      "name": "John Doe",
+      "gender": "male",
+      "email": "jd@example.com",
+      "phone": "55555",
+      "city": "some-city",
+      "age": "age"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -55,13 +55,13 @@ describe('Vero', function(){
     });
 
     describe('track', function(){
-     it('should map basic track', function(){
+      it('should map basic track', function(){
        test.maps('track-basic', {}, { ignored: [ 'auth_token' ] });
-     });
+      });
 
-    it('should map unsubscribe track', function(){
-      test.maps('track-unsubscribe', {}, { ignored: [ 'auth_token' ] });
-    });
+      it('should map unsubscribe track', function(){
+        test.maps('track-unsubscribe', {}, { ignored: [ 'auth_token' ] });
+      });
    });
 
     describe('group', function(){
@@ -100,6 +100,15 @@ describe('Vero', function(){
         .track(track.input)
         .sendsAlmost(track.output, { ignored: [ 'auth_token' ] })
         .pathname('/api/v2/users/unsubscribe')
+        .expects(200, done);
+    });
+
+    it('should map track with email set explicitly', function(done){
+      var track = test.fixture('track-with-email');
+      test
+        .set(settings)
+        .track(track.input)
+        .sendsAlmost(track.output, { ignored: [ 'auth_token' ] })
         .expects(200, done);
     });
   });


### PR DESCRIPTION
This pull request allows customers to explicitly track emails with `track` calls using the following library call as an example:

```
analytics.track(
  user_id: 'user-id',
  event: 'test event',
  properties: {
    a_property: 'test value'
  },
  context: { 
    traits: { email: 'user-email@example.com' }
  }
)
```
